### PR TITLE
escape spaces in buildgraph properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-01-12
+
+### Fixed
+
+- `uepyscripts.run.buildgraph` won't fail is no properties are passed
+- `uepyscripts.run.buildgraph` will surround properties that contain spaces with double quotes
+
 ## [1.1.0] - 2026-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) 
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/) 
-[![Version](https://img.shields.io/badge/version-1.0.0-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.1.1-green.svg)](CHANGELOG.md)
 
 ---
 

--- a/uepyscripts/run/buildgraph.py
+++ b/uepyscripts/run/buildgraph.py
@@ -127,8 +127,9 @@ def parse_arguments(argv=None):
     )
     parser.add_argument(
         "--properties", 
-        type=str, 
-        default="", 
+        type=str,
+        default=None,
+        nargs='?',
         help="JSON string representing a dictionary with the properties to pass to buildgraph. "
              "Ex: '{\"key1\": \"value1\", \"key2\": \"value2\"}'"
     )

--- a/uepyscripts/run/buildgraph.py
+++ b/uepyscripts/run/buildgraph.py
@@ -63,6 +63,8 @@ def run(
 
     if properties is not None:
         for key, value in properties.items():
+            if ' ' in value:
+                value = f'"{value}"'
             arguments.append(f"-set:{key}={value}")
 
     if extra_arguments is not None:


### PR DESCRIPTION
- **Surround buildgraph properties that contain a space with quotes**
- **Made the properties argument to run buildgraph optional**
- **Updated README and CHANGELOG**
