### PR TITLE
fix resolve engine egs not in registry

### DIFF
--- a/.changelog/14.added.md
+++ b/.changelog/14.added.md
@@ -1,0 +1,1 @@
+Try to find the engine installation path from LauncherInstalled.dat of the EGS program data when the information can't be found in the registry

--- a/src/uepyscripts/internal/engine.py
+++ b/src/uepyscripts/internal/engine.py
@@ -43,9 +43,9 @@ class Engine:
 
                 return -1
 
-    def __init__(self, project: Project) -> None:
+    def __init__(self, project: Project, root_path : Path) -> None:
         self.project = project
-        self.root_path = resolve_engine_path(project)
+        self.root_path = root_path
         self.path = self.root_path.joinpath("Engine").resolve()
         self.version = self.get_version_number()
         self.uat_path = self.Runner(self.path.joinpath("Build/BatchFiles/RunUAT.bat"), True)
@@ -101,6 +101,8 @@ class Engine:
 
 
 def resolve_engine(project: Project) -> Engine:
-    engine = Engine(project)
+    root_path = resolve_engine_path(project)
+
+    engine = Engine(project, root_path)
     logger.info(engine)
     return engine

--- a/src/uepyscripts/internal/engine.py
+++ b/src/uepyscripts/internal/engine.py
@@ -43,7 +43,7 @@ class Engine:
 
                 return -1
 
-    def __init__(self, project: Project, root_path : Path) -> None:
+    def __init__(self, project: Project, root_path: Path) -> None:
         self.project = project
         self.root_path = root_path
         self.path = self.root_path.joinpath("Engine").resolve()

--- a/src/uepyscripts/internal/engine_resolver.py
+++ b/src/uepyscripts/internal/engine_resolver.py
@@ -3,6 +3,8 @@ import winreg
 from pathlib import Path
 from typing import Optional
 
+from pydantic import BaseModel
+
 from ..internal.project import Project
 from ..tools.helpers import get_engine_root_folder_from_env_var, is_engine_from_egs
 from ..tools.winreg import get_registry_value
@@ -31,6 +33,43 @@ def resolve_engine_from_egs(project: Project) -> Optional[Path]:
             path = Path(registry_value)
             if path.exists():
                 return path
+            
+    # Some installations are listed in LauncherInstalled.dat            
+    class EpicInstallation(BaseModel):
+        InstallLocation: str
+        AppName: str
+        AppVersion: str
+
+        @property
+        def is_engine(self) -> bool:
+            """Checks if the installation is an Unreal Engine build."""
+            return self.AppName.startswith("UE_")
+
+    class LauncherInstalledData(BaseModel):
+        InstallationList: list[EpicInstallation]
+
+    def get_dat_file_path() -> Path:
+        # os.path.expandvars automatically replaces %PROGRAMDATA% with the actual path
+        raw_path = r"%PROGRAMDATA%\Epic\UnrealEngineLauncher\LauncherInstalled.dat"
+        expanded_path = Path(os.path.expandvars(raw_path))
+        
+        return expanded_path
+    
+    dat_path = get_dat_file_path()
+    if not dat_path.exists():
+        return None
+    
+    try:
+        with open(dat_path, "r", encoding="utf-8") as f:
+            json_str = f.read()
+            data = LauncherInstalledData.model_validate_json(json_str)
+        
+            for item in data.InstallationList:
+                if item.is_engine and item.AppVersion.startswith(project.engine_association):
+                    return Path(item.InstallLocation)
+                
+    except Exception as e:
+        print(f"Error parsing manifest: {e}")
 
     return None
 

--- a/src/uepyscripts/internal/engine_resolver.py
+++ b/src/uepyscripts/internal/engine_resolver.py
@@ -33,8 +33,8 @@ def resolve_engine_from_egs(project: Project) -> Optional[Path]:
             path = Path(registry_value)
             if path.exists():
                 return path
-            
-    # Some installations are listed in LauncherInstalled.dat            
+
+    # Some installations are listed in LauncherInstalled.dat
     class EpicInstallation(BaseModel):
         InstallLocation: str
         AppName: str
@@ -52,22 +52,22 @@ def resolve_engine_from_egs(project: Project) -> Optional[Path]:
         # os.path.expandvars automatically replaces %PROGRAMDATA% with the actual path
         raw_path = r"%PROGRAMDATA%\Epic\UnrealEngineLauncher\LauncherInstalled.dat"
         expanded_path = Path(os.path.expandvars(raw_path))
-        
+
         return expanded_path
-    
+
     dat_path = get_dat_file_path()
     if not dat_path.exists():
         return None
-    
+
     try:
         with open(dat_path, "r", encoding="utf-8") as f:
             json_str = f.read()
             data = LauncherInstalledData.model_validate_json(json_str)
-        
+
             for item in data.InstallationList:
                 if item.is_engine and item.AppVersion.startswith(project.engine_association):
                     return Path(item.InstallLocation)
-                
+
     except Exception as e:
         print(f"Error parsing manifest: {e}")
 


### PR DESCRIPTION
- **Resolve the engine path outside of the Engine constructor**
- **Get the engine installation in LauncherInstalled.dat from the EGS program data when no info can be found in the registry**
- **Added towncrier changelog entry**

Fixes #14
